### PR TITLE
Fix - item removal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -49,7 +49,7 @@ function App() {
 
   const handleRemoveFields = id => {
     const values  = [...inputFields];
-    values.splice(id, 1);
+    values.splice(values.findIndex(value => value.id === id), 1);
     setInputFields(values);
   }
 


### PR DESCRIPTION
Currently when removing an input field from list, it always removes the first item.

With this fix "findIndex", it will remove the item where clicked.